### PR TITLE
Major Loop Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ libbpf: failed to load object '/etc/xdpfwd/xdp_prog.o'
 
 It looks like general BPF loop [support](https://lwn.net/Articles/794934/) was added in kernel 5.3. Therefore, you'll need kernel 5.3 or above for this tool to run properly.
 
-With that said, the `bpf_loop()` function was added in kernel `6.2`. If you do not wish to upgrade your kernel to 6.2 or above, you will need to disable/comment out the `USE_NEW_LOOP` constant in the [`config.h`](./src/common/config.h) file. Please note if you do this, you will be **extremely limited** in how many concurrent source ports you can use (I recommend up to 21). Therefore, it is recommended you use `bpf_loop()` since you will have a much larger source port range!
+With that said, the `bpf_loop()` function was added in kernel `5.17`, but still requires `6.4` or above due to support for open coded iterators. If you do not wish to upgrade your kernel to 6.4 or above, you will need to disable/comment out the `USE_NEW_LOOP` constant in the [`config.h`](./src/common/config.h) file. Please note if you do this, you will be **extremely limited** in how many concurrent source ports you can use (I recommend up to 21). Therefore, it is recommended you use `bpf_loop()` since you will have a much larger source port range!
 
 ### Forward Rule Logging
 This tool uses `bpf_ringbuf_reserve()` and `bpf_ringbuf_submit()` for logging a message when a new connection is created if the forward rule has logging enabled.

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -11,7 +11,7 @@
 // The port range to use when selecting an available source port.
 // MAX_PORT - (MIN_PORT - 1) = The maximum amount of concurrent connections.
 #define MIN_PORT 500
-#define MAX_PORT 520
+#define MAX_PORT 900
 
 // Enables forward rule logging.
 #define ENABLE_RULE_LOGGING
@@ -33,3 +33,7 @@
 // Adds packet and last seen counters to connections.
 // This isn't used anywhere in the program right now which is why it's disabled by default.
 //#define CONNECTION_COUNTERS
+
+// If enabled, uses a newer bpf_loop() function when choosing a source port for a new connection.
+// This allows for a much higher source port range. However, it requires a more recent kernel.
+#define USE_NEW_LOOP

--- a/src/xdp/utils/helpers.c
+++ b/src/xdp/utils/helpers.c
@@ -1,7 +1,5 @@
 #include <xdp/utils/helpers.h>
 
-#include <xdp/utils/maps.h>
-
 /**
  * Swaps the Ethernet source and destination MAC addresses.
  * 

--- a/src/xdp/utils/port.c
+++ b/src/xdp/utils/port.c
@@ -1,0 +1,39 @@
+#include <xdp/utils/port.h>
+
+static __always_inline long choose_port(u32 idx, void* data)
+{
+    port_ctx_t* ctx = data;
+
+    u16 port = MIN_PORT + idx;
+
+    ctx->port_key.port = htons(port);
+
+    port_val_t *port_lookup = bpf_map_lookup_elem(&map_ports, &ctx->port_key);
+
+    if (!port_lookup)
+    {
+        ctx->port_to_use = port;
+        
+        return 1;
+    }
+
+#ifdef RECYCLE_LAST_SEEN
+    if (port_lookup->last_seen < ctx->last)
+    {
+        ctx->port_to_use = port;
+        ctx->last = port_lookup->last_seen;
+    }
+#else
+    if (port_lookup->count > 0)
+    {
+        u64 pps = (port_lookup->last_seen - port_lookup->first_seen) / port_lookup->count;
+        if (ctx->last > pps)
+        {
+            ctx->port_to_use = port;
+            ctx->last = pps;
+        }
+    }
+#endif
+
+    return 0;
+}

--- a/src/xdp/utils/port.h
+++ b/src/xdp/utils/port.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <common/all.h>
+
+#include <xdp/utils/maps.h>
+
+struct port_ctx
+{
+    u64 last;
+    u16 port_to_use;
+    port_key_t port_key;
+} typedef port_ctx_t;
+
+static __always_inline long choose_port(u32 idx, void* data);
+
+// The source file is included directly below instead of compiled and linked as an object because when linking, there is no guarantee the compiler will inline the function (which is crucial for performance).
+// I'd prefer not to include the function logic inside of the header file.
+// More Info: https://stackoverflow.com/questions/24289599/always-inline-does-not-work-when-function-is-implemented-in-different-file
+#include "port.c"


### PR DESCRIPTION
This PR adds the option to use a newer BPF helper function, [`bpf_loop()`](https://docs.ebpf.io/linux/helper-function/bpf_loop/). While the function itself was added in kernel `5.17`, open coded iterators wasn't added until kernel `6.4`. So you will need kernel `6.4` or above.

Using this newer function results in improvements to the BPF verifier and allows us to specify a much larger source port range using the `MIN_PORT` and `MAX_PORT` constants.